### PR TITLE
Parse values using `InvariantCulture`

### DIFF
--- a/MapBuilder.Library/Helpers/MapModelHelper.cs
+++ b/MapBuilder.Library/Helpers/MapModelHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Web.Script.Serialization;
 using MapBuilder.Library.Models;
@@ -89,7 +90,7 @@ namespace MapBuilder.Library.Helpers
                     model.Coordinates =
                         node.GetPropertyValue<string>(!string.IsNullOrWhiteSpace(coordsProperty)
                             ? coordsProperty
-                            : dataModel.CoordsProperty).Split(',').Select(double.Parse).ToArray();
+                            : dataModel.CoordsProperty).Split(',').Select(d => double.Parse(d, CultureInfo.InvariantCulture)).ToArray();
                     model.InfoWindowContent =
                         new RazorHelper().RenderPartialView("NcMapBuilder/InfoWindows/" + infoWindowName,
                             new InfoWindowModel {Id = node.Id});

--- a/MapBuilder.Library/Helpers/MapModelHelper.cs
+++ b/MapBuilder.Library/Helpers/MapModelHelper.cs
@@ -28,7 +28,7 @@ namespace MapBuilder.Library.Helpers
                 var apiResult = new ApiMapsModel
                 {
                     ApiKey = model.ApiKey,
-                    Center = model.Center.Split(',').Select(double.Parse).ToArray(),
+                    Center = model.Center.Split(',').Select(d => double.Parse(d, CultureInfo.InvariantCulture)).ToArray(),
                     CenterOnMarker = model.CenterOnMarker,
                     ClusterStyle = jss.Deserialize<List<ApiClusterStyleModel>>(model.ClusterStyle),
                     DefaultIconStyleModel = jss.Deserialize<ApiDefaultIconStyleModel>(model.DefaultIconStyle),


### PR DESCRIPTION
This fixes #20 

I'm wondering if the same fix should be applied around line 30 where the `double.Parse` function is used for the `Center` property?

(I haven't been able to test if that's also getting the wrong values but something tells me it might)